### PR TITLE
ReadHistoryMessagesJobを作成

### DIFF
--- a/app/controllers/servers_controller.rb
+++ b/app/controllers/servers_controller.rb
@@ -23,4 +23,16 @@ class ServersController < ApplicationController
       format.json { render :index, status: :created, location: servers_path }
     end
   end
+
+  def update
+    @server = Server.find(params[:id])
+
+    ReadHistoryMessagesJob.perform_later(@server) unless @server.updating
+
+    respond_to do |format|
+      flash[:notice] = '過去のメッセージを読み込んでいますので、後で戻ってください'
+      format.html { redirect_to root_path }
+      format.json { head :no_content }
+    end
+  end
 end

--- a/app/javascript/components/Selectors.jsx
+++ b/app/javascript/components/Selectors.jsx
@@ -190,7 +190,7 @@ const Selectors = (props) => {
       <div className="row">
         <div className="col-5 pe-1">
           <label id="server-label" htmlFor="server-input">
-            サーバー
+            <a className="text-decoration-none" href="/servers">サーバー</a>
           </label>
           <Select
             components={{

--- a/app/jobs/read_history_messages_job.rb
+++ b/app/jobs/read_history_messages_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReadHistoryMessagesJob < ApplicationJob
   queue_as :default
 

--- a/app/jobs/read_history_messages_job.rb
+++ b/app/jobs/read_history_messages_job.rb
@@ -1,0 +1,7 @@
+class ReadHistoryMessagesJob < ApplicationJob
+  queue_as :default
+
+  def perform(server)
+    server.read_history_messages
+  end
+end

--- a/app/views/servers/channels/index.html.slim
+++ b/app/views/servers/channels/index.html.slim
@@ -4,3 +4,5 @@
   - @channels.each do |channel|
     li.list-group-item.border-secondary
       = channel.name
+
+= link_to 'Read History Messages', server_path(@server), method: :patch, class: 'btn btn-primary btn-sm w-100 mt-3'

--- a/app/views/servers/index.html.slim
+++ b/app/views/servers/index.html.slim
@@ -6,7 +6,7 @@
       .d-flex.w-100.justify-content-between
         = link_to server.name, server_channels_path(server), class: 'text-decoration-none'
         small
-          - unless server.updating
+          - if !server.updating
             = link_to '過去統計', server_path(server), method: :patch, class: 'btn btn-secondary btn-sm py-0'
           - else
             | 進行中

--- a/app/views/servers/index.html.slim
+++ b/app/views/servers/index.html.slim
@@ -2,4 +2,11 @@
 
 .list-group.mt-3
   - @servers.each do |server|
-    = link_to server.name, server_channels_path(server), class: 'list-group-item list-group-item-action border-secondary'
+    .list-group-item.border-secondary
+      .d-flex.w-100.justify-content-between
+        = link_to server.name, server_channels_path(server), class: 'text-decoration-none'
+        small
+          - unless server.updating
+            = link_to '過去統計', server_path(server), method: :patch, class: 'btn btn-secondary btn-sm py-0'
+          - else
+            | 進行中

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   get '/auth/:provider/callback' => 'sessions#create'
   delete '/logout' => 'sessions#destroy'
 
-  resources :servers, only: %i[index create] do
+  resources :servers, only: %i[index create update] do
     resources :channels, only: %i[index create], controller: 'servers/channels'
     resources :periods, only: :index, controller: 'servers/periods'
   end

--- a/test/jobs/read_history_messages_job_test.rb
+++ b/test/jobs/read_history_messages_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class ReadHistoryMessagesJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/read_history_messages_job_test.rb
+++ b/test/jobs/read_history_messages_job_test.rb
@@ -1,4 +1,6 @@
-require "test_helper"
+# frozen_string_literal: true
+
+require 'test_helper'
 
 class ReadHistoryMessagesJobTest < ActiveJob::TestCase
   # test "the truth" do


### PR DESCRIPTION
Resolve #31 
ActiveJobを使って、過去メッセージを読み込んで、ランキング一覧を作成機能です。

![chatrank-async-leaderboard-create](https://user-images.githubusercontent.com/91442824/153156503-39382a2e-c72f-4c99-bf13-da7b597c8b2e.gif)
